### PR TITLE
Adding example of loading PIP-175K

### DIFF
--- a/examples/visym_pip_175k.ipynb
+++ b/examples/visym_pip_175k.ipynb
@@ -38,9 +38,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Download Dataset\n",
+    "## Download dataset\n",
     "\n",
-    "The dataset can be downloaded from [this page](https://visym.github.io/collector/pip_175k) via [this link (55.3GB)](https://dl.dropboxusercontent.com/s/xwiacwo9y5uci9v/pip_175k.tar.gz).\n"
+    "The dataset can be downloaded from [this page](https://visym.github.io/collector/pip_175k) via [this link (55.3GB)](https://dl.dropboxusercontent.com/s/xwiacwo9y5uci9v/pip_175k.tar.gz)."
    ]
   },
   {
@@ -120,7 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Quick Preview\n",
+    "## Quick preview\n",
     "\n",
     "FiftyOne provides native support for visualizing datasets stored as [video classification directory trees](https://voxel51.com/docs/fiftyone/user_guide/dataset_creation/datasets.html#videoclassificationdirectorytree) on disk, like the `pip_175k/videos/` sudirectory of the PIP-175K dataset.\n",
     "\n",
@@ -172,7 +172,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Loading the Dense Annotations\n",
+    "## Loading the full annotations\n",
     "\n",
     "We can load the complete annotations from the VIPY `.pkl` files by [writing a custom DatasetImporter](https://voxel51.com/docs/fiftyone/user_guide/dataset_creation/datasets.html#writing-a-custom-datasetimporter):"
    ]


### PR DESCRIPTION
In this example, we load the [People in Public 175K Dataset](https://visym.github.io/collector/pip_175k) from [Visym Labs](https://www.visym.com/site_0820/index.html) into FiftyOne.

![2020-10-23 13 04 34](https://user-images.githubusercontent.com/25985824/97036710-3665f180-1536-11eb-96b5-1054b62530a8.gif)
