### PR TITLE
Update fiftyone.utils.splits for Qdrant example

### DIFF
--- a/examples/Qdrant_FiftyOne_Recipe.ipynb
+++ b/examples/Qdrant_FiftyOne_Recipe.ipynb
@@ -917,9 +917,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import fiftyone.utils.splits as fous\n",
+    "import fiftyone.utils.random as four\n",
     "\n",
-    "fous.random_split(dataset, {\"train\": 0.7, \"test\": 0.3})\n",
+    "four.random_split(dataset, {\"train\": 0.7, \"test\": 0.3})\n",
     "\n",
     "train_view = dataset.match_tags(\"train\")\n",
     "test_view = dataset.match_tags(\"test\")\n",


### PR DESCRIPTION
Update fiftyone.utils.splits to use `fiftyone.utils.random` for Qdrant example